### PR TITLE
Atom v1.13.0 shadow dom deprecation fix

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -13,7 +13,7 @@ atom-text-editor[mini] {
   height:24px;
 
   &,
-  &::shadow {
+  &.editor {
     .placeholder-text {
       color: @text-color-subtle;
     }
@@ -27,7 +27,7 @@ atom-text-editor[mini] {
   }
 
   &.is-focused,
-  &.is-focused::shadow {
+  &.is-focused.editor {
     background-color: #fff;
     opacity:1;
     outline:none;


### PR DESCRIPTION
Replace ::Shadow dom pseudo-selectors in editor.less to update compatibility with Atom v1.13+.  Per Deprecation cop output. Not sure we need secondary .editor selectors in addition to the the first ones. remove if unnecessary.